### PR TITLE
prefer gitrepo.<target>.token > privatekey, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ To configure `git-repo` you need to tweak your `~/.gitconfig`. For each service
 you've got an account on, you have to make a section in the gitconfig:
 
     [gitrepo "gitlab"]
-        private_token = YourVerySecretKey
+        token = YourVerySecretKey
 
     [gitrepo "github"]
-        private_token = YourOtherVerySecretKey
+        token = YourOtherVerySecretKey
 
     [gitrepo "bitbucket"]
-        private_token = username:password
+        token = username:password
 
 Here, we're setting the basics: just the private token. You'll notice that for bitbucket
 the private token is your username and password seperated by a column. That's because
@@ -94,7 +94,7 @@ You also have the ability to set up an alias:
 
     [gitrepo "bitbucket"]
         alias = bit
-        private_token = username:password
+        token = username:password
 
 that will change the command you use for a name you'll prefer to handle actions
 for the service you use:
@@ -105,7 +105,7 @@ Also, you can setup your own gitlab self-hosted server, using that configuration
 
     [gitrepo "myprecious"]
         type = gitlab
-        private_token = YourSuperPrivateKey
+        token = YourSuperPrivateKey
         fqdn = gitlab.example.org
 
 Finally, to make it really cool, you can make a few aliases in your gitconfig:

--- a/git_repo/repo.py
+++ b/git_repo/repo.py
@@ -38,18 +38,18 @@ Options for add:
 Configuration options:
     alias                    Name to use for the git remote
     url                      URL of the repository
-    private-key              Private key to use for connecting to the service
+    token                    Private token to use for connecting to the service
     type                     Name of the service to use (github, gitlab, bitbucket)
 
 Configuration example:
 
 [gitrepo "gitlab"]
-    private-key = YourSecretKey
+    token = yourapitoken
     alias = lab
 
 [gitrepo "personal"]
     type = gitlab
-    private-key = YourSecretKey
+    token = yourapitoken
     url = http://custom.org
 
 {self} version {version}, Copyright ⓒ2016 Bernard `Guyzmo` Pratz

--- a/git_repo/services/service.py
+++ b/git_repo/services/service.py
@@ -138,11 +138,13 @@ class RepositoryService:
                 self.name = name
         # if not in the configuration file, retrieve the private key from the
         # environment (useful for travis configuration), otherwise, make it None.
-        # using "privatekey" or "private_token" in configuration file to avoid
+        # using "token" > "private_token" > "privatekey" in configuration file to avoid
         # confusion with the SSH keys (yes that happened).
+        # NB: `git config` doesn't parse underscores in option names, token.
         self._privatekey = os.environ.get('PRIVATE_KEY_{}'.format(self.name.upper()),
-                                          c.get('private_token',
-                                                c.get('privatekey', None)))
+                                          c.get('token',
+                                                c.get('private_token',
+                                                      c.get('privatekey', None))))
         self._alias = c.get('alias', self.name)
         self.fqdn = c.get('fqdn', self.fqdn)
 


### PR DESCRIPTION
Fixes an inconsistency in the docs between `private-key` and `privatekey`.
Git config does not parse `private_token` easily in gitconfig, so here I propose using just `token`.
