### PR TITLE
Fixed github name != username issue

### DIFF
--- a/git_repo/services/ext/github.py
+++ b/git_repo/services/ext/github.py
@@ -21,8 +21,7 @@ class GithubService(RepositoryService):
     def connect(self):
         try:
             self.gh.login(token=self._privatekey)
-            self.username = self.gh.user().name
-            self.username = self.gh.user().name
+            self.username = self.gh.user().login
         except github3.models.GitHubError as err:
             if err.code is 401:
                 if not self._privatekey:
@@ -81,7 +80,7 @@ class GithubService(RepositoryService):
 
     def gist_list(self, gist=None):
         if not gist:
-            for gist in self.gh.iter_gists(self.gh.user().name):
+            for gist in self.gh.iter_gists(self.gh.user().login):
                 yield (gist.html_url, gist.description)
         else:
             gist = self.gh.gist(self._format_gist(gist))
@@ -208,5 +207,5 @@ class GithubService(RepositoryService):
 
     @property
     def user(self):
-        return self.gh.user().name
+        return self.gh.user().login
 


### PR DESCRIPTION
Details:

My github username(gh.user().login) is `buaazp` while my github name is `招牌疯子`, so the remote url is wrong after I fork a repo.
```
[zippo@rMBP] ➜ git-repo (master) git remote -v
all	git@github.com:guyzmo/git-repo (fetch)
all	git@github.com:guyzmo/git-repo (push)
github	git@github.com:guyzmo/git-repo (fetch)
github	git@github.com:guyzmo/git-repo (push)

[zippo@rMBP] ➜ git-repo (master) git hub fork
Forking repository guyzmo/git-repo…
New forked repository available at https://github.com/buaazp/git-repo

[zippo@rMBP] ➜ git-repo (master) git remote -v
all	git@github.com:招牌疯子/git-repo (push)
all	git@github.com:guyzmo/git-repo (fetch)
all	git@github.com:guyzmo/git-repo (push)
github	git@github.com:招牌疯子/git-repo (fetch)
github	git@github.com:招牌疯子/git-repo (push)
upstream	git@github.com:guyzmo/git-repo (fetch)
upstream	git@github.com:guyzmo/git-repo (push)
```