### PR TITLE
Allow cloning into exisiting empty directories

### DIFF
--- a/git_repo/repo.py
+++ b/git_repo/repo.py
@@ -323,9 +323,10 @@ class GitRepoRunner(KeywordArgumentParser):
     def do_clone(self, service=None, repo_path=None):
         service = service or self.get_service(lookup_repository=False)
         repo_path = repo_path or os.path.join(self.path, self.target_repo or self.repo_name)
-        if os.path.exists(repo_path):
+        if os.path.exists(repo_path) and os.listdir(repo_path) != []:
             raise FileExistsError('Cannot clone repository, '
-                                  'a folder named {} already exists!'.format(repo_path))
+                                  'a folder named {} already exists and '
+                                  'is not an empty directory!'.format(repo_path))
         try:
             repository = Repo.init(repo_path)
             service = RepositoryService.get_service(repository, self.target)


### PR DESCRIPTION
Fixes #58 

Once again had some trouble trying to write an integration test for this. The test setup automatically does a git init, manually removing the `.git` directory breaks a lot of other stuff. Any hints? :)
