### PR TITLE
🚧 Add 'insecure' config option to allow self signed certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ Also, you can setup your own GitLab self-hosted server, using that configuration
         type = gitlab
         token = YourSuperPrivateKey
         fqdn = gitlab.example.org
+        # Set this only if you use a self-signed certificate and experience problems
+        insecure = true
 
 Finally, to make it really cool, you can make a few aliases in your gitconfig:
 

--- a/git_repo/services/ext/gitlab.py
+++ b/git_repo/services/ext/gitlab.py
@@ -16,8 +16,8 @@ class GitlabService(RepositoryService):
     fqdn = 'gitlab.com'
 
     def __init__(self, *args, **kwarg):
-        self.gl = gitlab.Gitlab(self.url_ro)
-        super(GitlabService, self).__init__(*args, **kwarg)
+        super().__init__(*args, **kwarg)
+        self.gl = gitlab.Gitlab(self.url_ro, ssl_verify=not self.insecure)
 
     def connect(self):
         self.gl.set_url(self.url_ro)

--- a/git_repo/services/service.py
+++ b/git_repo/services/service.py
@@ -156,6 +156,7 @@ class RepositoryService:
                                                       c.get('privatekey', None))))
         self._alias = c.get('alias', self.name)
         self.fqdn = c.get('fqdn', self.fqdn)
+        self.insecure = c.get('insecure', False)
 
         # if service has a repository configured, connect
         if r:

--- a/git_repo/services/service.py
+++ b/git_repo/services/service.py
@@ -156,7 +156,7 @@ class RepositoryService:
                                                       c.get('privatekey', None))))
         self._alias = c.get('alias', self.name)
         self.fqdn = c.get('fqdn', self.fqdn)
-        self.insecure = c.get('insecure', False)
+        self.insecure = c.get('insecure', 'false').lower() in ('on', 'true', 'yes', '1')
 
         # if service has a repository configured, connect
         if r:


### PR DESCRIPTION
If connecting to a GitLab instance which uses a self signed certificate,
the connection would fail. This option allows for a workaround to
disable verification at all.