### PR TITLE
🚒 Fixes issue when adding remote upon git-repo create


### DIFF
--- a/git_repo/services/ext/github.py
+++ b/git_repo/services/ext/github.py
@@ -51,7 +51,7 @@ class GithubService(RepositoryService):
             else: # pragma: no cover
                 raise ResourceError("Unhandled error.") from err
         if add:
-            self.add(user=self.username, repo=repo, tracking=self.name)
+            self.add(user=user, repo=repo, tracking=self.name)
 
     def fork(self, user, repo):
         try:


### PR DESCRIPTION


instead of adding as remote the project under the current user's
namespace, we now adds it to the specified namespace, whichever this is.

fixes #101

