### PR TITLE
🚒 updates and fixes to the list command


### DIFF
--- a/git_repo/services/ext/github.py
+++ b/git_repo/services/ext/github.py
@@ -85,10 +85,10 @@ class GithubService(RepositoryService):
         if not _long:
             repositories = list(["/".join([user, repo.name]) for repo in repositories])
             yield "{}"
-            yield "Total repositories: {}".format(len(repositories))
+            yield ("Total repositories: {}".format(len(repositories)),)
             yield from columnize(repositories)
         else:
-            yield "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t\t{}"
+            yield "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:12}\t{}"
             yield ['Status', 'Commits', 'Reqs', 'Issues', 'Forks', 'Coders', 'Watch', 'Likes', 'Lang', 'Modif', 'Name']
             for repo in repositories:
                 try:

--- a/git_repo/services/ext/gitlab.py
+++ b/git_repo/services/ext/gitlab.py
@@ -14,6 +14,8 @@ from git.exc import GitCommandError
 
 import os
 import json, time
+import dateutil.parser
+from datetime import datetime
 
 @register_target('lab', 'gitlab')
 class GitlabService(RepositoryService):
@@ -82,16 +84,18 @@ class GitlabService(RepositoryService):
         if not _long:
             repositories = list([repo.path_with_namespace for repo in repositories])
             yield "{}"
-            yield "Total repositories: {}".format(len(repositories))
+            yield ("Total repositories: {}".format(len(repositories)),)
             yield from columnize(repositories)
         else:
+            yield "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:12}\t{}"
             yield ['Status', 'Commits', 'Reqs', 'Issues', 'Forks', 'Coders', 'Watch', 'Likes', 'Lang', 'Modif\t', 'Name']
             for repo in repositories:
                 time.sleep(0.5)
-                # if repo.last_activity_at.year < datetime.now().year:
-                #     date_fmt = "%b %d %Y"
-                # else:
-                #     date_fmt = "%b %d %H:%M"
+                repo_last_activity_at = dateutil.parser.parse(repo.last_activity_at)
+                if repo_last_activity_at.year < datetime.now().year:
+                    date_fmt = "%b %d %Y"
+                else:
+                    date_fmt = "%b %d %H:%M"
 
                 status = ''.join([
                     'F' if False else ' ',               # is a fork?
@@ -110,7 +114,7 @@ class GitlabService(RepositoryService):
                     str(repo.star_count),                      # number of ♥
                                                                # info
                     'N.A.',                                    # language
-                    repo.last_activity_at,                     # date
+                    repo_last_activity_at.strftime(date_fmt),  # date
                     repo.name_with_namespace,                  # name
                 ]
 

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -354,12 +354,12 @@ class Test_Github(GitRepoTestCase):
 
     def test_34_list__short(self, caplog):
         projects = self.action_list(namespace='git-repo-test')
-        assert projects == ['{}', 'Total repositories: 1', ['git-repo-test/git-repo']]
+        assert projects == ['{}', ('Total repositories: 1',), ['git-repo-test/git-repo']]
         assert 'GET https://api.github.com/users/git-repo-test/repos' in caplog.text
 
     def test_34_list__long(self, caplog):
         projects = self.action_list(namespace='git-repo-test', _long=True)
-        assert projects == ['{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t\t{}',
+        assert projects == ['{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:12}\t{}',
                 ['Status', 'Commits', 'Reqs', 'Issues', 'Forks', 'Coders', 'Watch', 'Likes', 'Lang', 'Modif', 'Name'],
                 ['F ', '92', '0', '0', '0', '1', '0', '0', 'Python', 'Mar 30 2016', 'git-repo-test/git-repo']]
         assert 'GET https://api.github.com/users/git-repo-test/repos' in caplog.text


### PR DESCRIPTION


fixing missing format yield in gogs list,
made the header yield a tuple in all three non-long lists
made the ISO date parsed and showing the same nice output as github

fixes #124

