### PR TITLE
Add GitBucket support (refs #142)

### DIFF
--- a/git_repo/repo.py
+++ b/git_repo/repo.py
@@ -165,13 +165,13 @@ class GitRepoRunner(KeywordArgumentParser):
                 for url in remote.urls:
                     if url.endswith('.git'):
                         url = url[:-4]
-                    if url.find('://') > -1:
-                        # http://, https:// and ssh://
+                    # strip http://, https:// and ssh://
+                    if '://' in url:
                         *_, user, name = url.split('/')
                         self.set_repo_slug('/'.join([user, name]))
                         return
-                    elif url.find('@') > -1 and url.find(':') > -1:
-                        # scp-style URL
+                    # scp-style URL
+                    elif '@' in url and ':' in url:
                         _, repo_slug = url.split(':')
                         self.set_repo_slug(repo_slug)
                         return

--- a/git_repo/services/ext/gitbucket.py
+++ b/git_repo/services/ext/gitbucket.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+import logging
+log = logging.getLogger('git_repo.gitbucket')
+
+from ..service import register_target
+from .github import GithubService
+
+import github3
+
+@register_target('bucket', 'gitbucket')
+class GitbucketService(GithubService):
+    fqdn = "localhost"
+    port = 8080
+    def __init__(self, *args, **kwarg):
+        super(GitbucketService, self).__init__(*args, **kwarg)
+
+    def connect(self):
+        self.gh = github3.GitHubEnterprise(self.build_url(self))
+        super(GitbucketService, self).connect()
+
+    @classmethod
+    def get_auth_token(cls, login, password, prompt=None):
+        print("Please edit _YOUR_ACCESS_TOKEN_ to actual token in ~/.gitconfig or ~/.git/config after.")
+        print("And add ssh-url = ssh://git@{}:_YOUR_SSH_PORT_".format(cls.fqdn))
+        return "_YOUR_ACCESS_TOKEN_"
+        ## this code maybe works when GitBucket supports add access token API.
+        #print("build_url: ", cls.build_url(cls))
+        #import platform
+        #gh = github3.GitHubEnterprise(cls.build_url(cls))
+        #gh.login(login, password, two_factor_callback=lambda: prompt('2FA code> '))
+        #try:
+        #    auth = gh.authorize(login, password,
+        #            scopes=[ 'repo', 'delete_repo', 'gist' ],
+        #            note='git-repo2 token used on {}'.format(platform.node()),
+        #            note_url='https://github.com/guyzmo/git-repo')
+        #    return auth.token
+        #except github3.models.GitHubError as err:
+        #    if len(err.args) > 0 and 422 == err.args[0].status_code:
+        #        raise ResourceExistsError("A token already exist for this machine on your github account.")
+        #    else:
+        #        raise err
+
+    def format_path(self, repository, namespace=None, rw=False):
+        path = super(GitbucketService, self).format_path(repository, namespace, rw)
+        if not path.endswith(".git"):
+            path = "{}.git".format(path)
+        return path
+
+    def delete(self, repo, user=None):
+        raise NotImplementedError("GitBucket doesn't suport this action now.")
+
+    def request_create(self, user, repo, from_branch, onto_branch, title=None, description=None, auto_slug=False, edit=None):
+        raise NotImplementedError("GitBucket doesn't support this action now.")
+
+    def gist_list(self, gist=None):
+        raise NotImplementedError("GitBucket doesn't support manipulate gist by API.")
+
+    def gist_fetch(self, gist, fname=None):
+        raise NotImplementedError("GitBucket doesn't support manipulate gist by API.")
+
+    def gist_clone(self, gist):
+        raise NotImplementedError("GitBucket doesn't support manipulate gist by API.")
+
+    def gist_create(self, gist_pathes, description, secret=False):
+        raise NotImplementedError("GitBucket doesn't support manipulate gist by API.")
+
+    def gist_delete(self, gist_id):
+        raise NotImplementedError("GitBucket doesn't support manipulate gist by API.")

--- a/git_repo/services/ext/github.py
+++ b/git_repo/services/ext/github.py
@@ -28,6 +28,7 @@ class GithubService(RepositoryService):
             # upgrade self.gh from a GitHub object to a GitHubEnterprise object
             gh = github3.GitHubEnterprise(RepositoryService.build_url(self))
             self.gh._session.base_url = gh._session.base_url
+            gh._session = self.gh._session
             self.gh = gh
             # propagate ssl certificate parameter
             self.gh._session.verify = self.session_certificate or not self.session_insecure

--- a/git_repo/services/ext/github.py
+++ b/git_repo/services/ext/github.py
@@ -13,15 +13,24 @@ from git.exc import GitCommandError
 
 from datetime import datetime
 
+GITHUB_COM_FQDN = 'github.com'
+
 @register_target('hub', 'github')
 class GithubService(RepositoryService):
-    fqdn = 'github.com'
+    fqdn = GITHUB_COM_FQDN
 
     def __init__(self, *args, **kwarg):
         self.gh = github3.GitHub()
         super(GithubService, self).__init__(*args, **kwarg)
 
     def connect(self):
+        if self.fqdn != GITHUB_COM_FQDN:
+            # upgrade self.gh from a GitHub object to a GitHubEnterprise object
+            gh = github3.GitHubEnterprise(RepositoryService.build_url(self))
+            self.gh._session.base_url = gh._session.base_url
+            self.gh = gh
+            # propagate ssl certificate parameter
+            self.gh._session.verify = self.session_certificate or not self.session_insecure
         try:
             self.gh.login(token=self._privatekey)
             self.username = self.gh.user().login

--- a/git_repo/services/ext/github.py
+++ b/git_repo/services/ext/github.py
@@ -284,7 +284,7 @@ class GithubService(RepositoryService):
         try:
             for remote in self.repository.remotes:
                 if remote.name == self.name:
-                    local_branch_name = 'requests/github/{}'.format(request)
+                    local_branch_name = 'requests/{}/{}'.format(self.name,request)
                     self.fetch(
                         remote,
                         'pull/{}/head'.format(request),

--- a/tests/integration/cassettes/test_gitbucket_test_00_fork.json
+++ b/tests/integration/cassettes/test_gitbucket_test_00_fork.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:07",
+      "recorded_at": "2017-04-30T17:42:17",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,30 +17,30 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:07 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:17 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1dd4251vplb7xqulhumautyo;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=odn4jua2ecnf5isyma6dbo21;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     },
     {
-      "recorded_at": "2017-04-30T17:31:07",
+      "recorded_at": "2017-04-30T17:42:17",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -53,7 +53,7 @@
           "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
           "Connection": "keep-alive",
           "Content-Type": "application/json",
-          "Cookie": "JSESSIONID=1dd4251vplb7xqulhumautyo",
+          "Cookie": "JSESSIONID=odn4jua2ecnf5isyma6dbo21",
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
@@ -62,12 +62,12 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"name\":\"repo\",\"full_name\":\"root/repo\",\"description\":\"\",\"watchers\":0,\"forks\":0,\"private\":false,\"default_branch\":\"master\",\"owner\":{\"login\":\"root\",\"email\":\"root@localhost\",\"type\":\"User\",\"site_admin\":true,\"created_at\":\"2017-04-30T17:30:37Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/root\",\"html_url\":\"http://localhost:8080/root\",\"avatar_url\":\"http://localhost:8080/root/_avatar\"},\"forks_count\":0,\"watchers_count\":0,\"url\":\"http://localhost:8080/api/v3/repos/root/repo\",\"http_url\":\"http://localhost:8080/git/root/repo.git\",\"clone_url\":\"http://localhost:8080/git/root/repo.git\",\"html_url\":\"http://localhost:8080/root/repo\"}"
+          "string": "{\"name\":\"repo\",\"full_name\":\"root/repo\",\"description\":\"\",\"watchers\":0,\"forks\":0,\"private\":false,\"default_branch\":\"master\",\"owner\":{\"login\":\"root\",\"email\":\"root@localhost\",\"type\":\"User\",\"site_admin\":true,\"created_at\":\"2017-04-30T17:39:28Z\",\"url\":\"http://localhost:8080/api/v3/users/root\",\"html_url\":\"http://localhost:8080/root\",\"avatar_url\":\"http://localhost:8080/root/_avatar\"},\"forks_count\":0,\"watchers_count\":0,\"url\":\"http://localhost:8080/api/v3/repos/root/repo\",\"http_url\":\"http://localhost:8080/git/root/repo.git\",\"clone_url\":\"http://localhost:8080/git/root/repo.git\",\"html_url\":\"http://localhost:8080/root/repo\"}"
         },
         "headers": {
           "Content-Length": "617",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:07 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:17 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)"
         },
         "status": {
@@ -78,7 +78,7 @@
       }
     },
     {
-      "recorded_at": "2017-04-30T17:31:14",
+      "recorded_at": "2017-04-30T17:42:24",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -92,7 +92,7 @@
           "Connection": "keep-alive",
           "Content-Length": "0",
           "Content-Type": "application/json",
-          "Cookie": "JSESSIONID=1dd4251vplb7xqulhumautyo",
+          "Cookie": "JSESSIONID=odn4jua2ecnf5isyma6dbo21",
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "POST",
@@ -105,7 +105,7 @@
         },
         "headers": {
           "Content-Length": "0",
-          "Date": "Sun, 30 Apr 2017 17:31:07 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:17 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)"
         },
         "status": {

--- a/tests/integration/cassettes/test_gitbucket_test_00_fork.json
+++ b/tests/integration/cassettes/test_gitbucket_test_00_fork.json
@@ -1,0 +1,120 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:25 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=elg1zmdohhji2r0q9zxilcck;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    },
+    {
+      "recorded_at": "2017-04-30T17:11:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "Cookie": "JSESSIONID=elg1zmdohhji2r0q9zxilcck",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/repos/root/repo"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"name\":\"repo\",\"full_name\":\"root/repo\",\"description\":\"\",\"watchers\":0,\"forks\":0,\"private\":false,\"default_branch\":\"master\",\"owner\":{\"login\":\"root\",\"email\":\"root@localhost\",\"type\":\"User\",\"site_admin\":true,\"created_at\":\"2017-04-30T15:09:00Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/root\",\"html_url\":\"http://localhost:8080/root\",\"avatar_url\":\"http://localhost:8080/root/_avatar\"},\"forks_count\":0,\"watchers_count\":0,\"url\":\"http://localhost:8080/api/v3/repos/root/repo\",\"http_url\":\"http://localhost:8080/git/root/repo.git\",\"clone_url\":\"http://localhost:8080/git/root/repo.git\",\"html_url\":\"http://localhost:8080/root/repo\"}"
+        },
+        "headers": {
+          "Content-Length": "617",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:25 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/repos/root/repo"
+      }
+    },
+    {
+      "recorded_at": "2017-04-30T17:11:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Length": "0",
+          "Content-Type": "application/json",
+          "Cookie": "JSESSIONID=elg1zmdohhji2r0q9zxilcck",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "POST",
+        "uri": "http://localhost:8080/api/v3/repos/root/repo/forks"
+      },
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": ""
+        },
+        "headers": {
+          "Content-Length": "0",
+          "Date": "Sun, 30 Apr 2017 17:11:25 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)"
+        },
+        "status": {
+          "code": 404,
+          "message": "Not Found"
+        },
+        "url": "http://localhost:8080/api/v3/repos/root/repo/forks"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_00_fork.json
+++ b/tests/integration/cassettes/test_gitbucket_test_00_fork.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:25",
+      "recorded_at": "2017-04-30T17:31:07",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:25 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:07 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=elg1zmdohhji2r0q9zxilcck;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1dd4251vplb7xqulhumautyo;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
@@ -40,7 +40,7 @@
       }
     },
     {
-      "recorded_at": "2017-04-30T17:11:25",
+      "recorded_at": "2017-04-30T17:31:07",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -53,7 +53,7 @@
           "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
           "Connection": "keep-alive",
           "Content-Type": "application/json",
-          "Cookie": "JSESSIONID=elg1zmdohhji2r0q9zxilcck",
+          "Cookie": "JSESSIONID=1dd4251vplb7xqulhumautyo",
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
@@ -62,12 +62,12 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"name\":\"repo\",\"full_name\":\"root/repo\",\"description\":\"\",\"watchers\":0,\"forks\":0,\"private\":false,\"default_branch\":\"master\",\"owner\":{\"login\":\"root\",\"email\":\"root@localhost\",\"type\":\"User\",\"site_admin\":true,\"created_at\":\"2017-04-30T15:09:00Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/root\",\"html_url\":\"http://localhost:8080/root\",\"avatar_url\":\"http://localhost:8080/root/_avatar\"},\"forks_count\":0,\"watchers_count\":0,\"url\":\"http://localhost:8080/api/v3/repos/root/repo\",\"http_url\":\"http://localhost:8080/git/root/repo.git\",\"clone_url\":\"http://localhost:8080/git/root/repo.git\",\"html_url\":\"http://localhost:8080/root/repo\"}"
+          "string": "{\"name\":\"repo\",\"full_name\":\"root/repo\",\"description\":\"\",\"watchers\":0,\"forks\":0,\"private\":false,\"default_branch\":\"master\",\"owner\":{\"login\":\"root\",\"email\":\"root@localhost\",\"type\":\"User\",\"site_admin\":true,\"created_at\":\"2017-04-30T17:30:37Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/root\",\"html_url\":\"http://localhost:8080/root\",\"avatar_url\":\"http://localhost:8080/root/_avatar\"},\"forks_count\":0,\"watchers_count\":0,\"url\":\"http://localhost:8080/api/v3/repos/root/repo\",\"http_url\":\"http://localhost:8080/git/root/repo.git\",\"clone_url\":\"http://localhost:8080/git/root/repo.git\",\"html_url\":\"http://localhost:8080/root/repo\"}"
         },
         "headers": {
           "Content-Length": "617",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:25 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:07 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)"
         },
         "status": {
@@ -78,7 +78,7 @@
       }
     },
     {
-      "recorded_at": "2017-04-30T17:11:31",
+      "recorded_at": "2017-04-30T17:31:14",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -92,7 +92,7 @@
           "Connection": "keep-alive",
           "Content-Length": "0",
           "Content-Type": "application/json",
-          "Cookie": "JSESSIONID=elg1zmdohhji2r0q9zxilcck",
+          "Cookie": "JSESSIONID=1dd4251vplb7xqulhumautyo",
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "POST",
@@ -105,7 +105,7 @@
         },
         "headers": {
           "Content-Length": "0",
-          "Date": "Sun, 30 Apr 2017 17:11:25 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:07 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)"
         },
         "status": {

--- a/tests/integration/cassettes/test_gitbucket_test_01_create__already_exists.json
+++ b/tests/integration/cassettes/test_gitbucket_test_01_create__already_exists.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:36",
+      "recorded_at": "2017-04-30T17:31:19",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:36 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:19 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=xkncl73xsy4y1aih0cd7kkxo4;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1t0htrr6dcqy7zaocy5rln907;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
@@ -40,11 +40,11 @@
       }
     },
     {
-      "recorded_at": "2017-04-30T17:11:36",
+      "recorded_at": "2017-04-30T17:31:19",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"description\": \"\", \"auto_init\": false, \"private\": false, \"has_downloads\": true, \"name\": \"git-repo\", \"has_wiki\": true, \"has_issues\": true, \"gitignore_template\": \"\", \"homepage\": \"\"}"
+          "string": "{\"private\": false, \"has_downloads\": true, \"homepage\": \"\", \"name\": \"git-repo\", \"has_issues\": true, \"gitignore_template\": \"\", \"has_wiki\": true, \"description\": \"\", \"auto_init\": false}"
         },
         "headers": {
           "Accept": "application/vnd.github.v3.full+json",
@@ -54,7 +54,7 @@
           "Connection": "keep-alive",
           "Content-Length": "180",
           "Content-Type": "application/json",
-          "Cookie": "JSESSIONID=xkncl73xsy4y1aih0cd7kkxo4",
+          "Cookie": "JSESSIONID=1t0htrr6dcqy7zaocy5rln907",
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "POST",
@@ -63,12 +63,12 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"message\":\"A repository with this name already exists on this account\",\"documentation_url\":\"https://developer.github.com/v3/repos/#create\"}"
+          "string": "{\"name\":\"git-repo\",\"full_name\":\"<GITBUCKET_NAMESPACE>/git-repo\",\"description\":\"\",\"watchers\":0,\"forks\":0,\"private\":false,\"default_branch\":\"master\",\"owner\":{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"},\"forks_count\":0,\"watchers_count\":0,\"url\":\"http://localhost:8080/api/v3/repos/<GITBUCKET_NAMESPACE>/git-repo\",\"http_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/git-repo.git\",\"clone_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/git-repo.git\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/git-repo\"}"
         },
         "headers": {
-          "Content-Length": "140",
+          "Content-Length": "642",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:36 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:19 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)"
         },
         "status": {
@@ -79,7 +79,7 @@
       }
     },
     {
-      "recorded_at": "2017-04-30T17:11:36",
+      "recorded_at": "2017-04-30T17:31:20",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -92,7 +92,7 @@
           "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
           "Connection": "keep-alive",
           "Content-Type": "application/json",
-          "Cookie": "JSESSIONID=xkncl73xsy4y1aih0cd7kkxo4",
+          "Cookie": "JSESSIONID=1t0htrr6dcqy7zaocy5rln907",
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
@@ -101,12 +101,12 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"name\":\"git-repo\",\"full_name\":\"<GITBUCKET_NAMESPACE>/git-repo\",\"description\":\"\",\"watchers\":0,\"forks\":0,\"private\":false,\"default_branch\":\"master\",\"owner\":{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"},\"forks_count\":0,\"watchers_count\":0,\"url\":\"http://localhost:8080/api/v3/repos/<GITBUCKET_NAMESPACE>/git-repo\",\"http_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/git-repo.git\",\"clone_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/git-repo.git\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/git-repo\"}"
+          "string": "{\"name\":\"git-repo\",\"full_name\":\"<GITBUCKET_NAMESPACE>/git-repo\",\"description\":\"\",\"watchers\":0,\"forks\":0,\"private\":false,\"default_branch\":\"master\",\"owner\":{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"},\"forks_count\":0,\"watchers_count\":0,\"url\":\"http://localhost:8080/api/v3/repos/<GITBUCKET_NAMESPACE>/git-repo\",\"http_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/git-repo.git\",\"clone_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/git-repo.git\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/git-repo\"}"
         },
         "headers": {
           "Content-Length": "642",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:36 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:20 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)"
         },
         "status": {

--- a/tests/integration/cassettes/test_gitbucket_test_01_create__already_exists.json
+++ b/tests/integration/cassettes/test_gitbucket_test_01_create__already_exists.json
@@ -1,0 +1,121 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:36 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=xkncl73xsy4y1aih0cd7kkxo4;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    },
+    {
+      "recorded_at": "2017-04-30T17:11:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"description\": \"\", \"auto_init\": false, \"private\": false, \"has_downloads\": true, \"name\": \"git-repo\", \"has_wiki\": true, \"has_issues\": true, \"gitignore_template\": \"\", \"homepage\": \"\"}"
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Length": "180",
+          "Content-Type": "application/json",
+          "Cookie": "JSESSIONID=xkncl73xsy4y1aih0cd7kkxo4",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "POST",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>/repos"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"message\":\"A repository with this name already exists on this account\",\"documentation_url\":\"https://developer.github.com/v3/repos/#create\"}"
+        },
+        "headers": {
+          "Content-Length": "140",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:36 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>/repos"
+      }
+    },
+    {
+      "recorded_at": "2017-04-30T17:11:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "Cookie": "JSESSIONID=xkncl73xsy4y1aih0cd7kkxo4",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/repos/<GITBUCKET_NAMESPACE>/git-repo"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"name\":\"git-repo\",\"full_name\":\"<GITBUCKET_NAMESPACE>/git-repo\",\"description\":\"\",\"watchers\":0,\"forks\":0,\"private\":false,\"default_branch\":\"master\",\"owner\":{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"},\"forks_count\":0,\"watchers_count\":0,\"url\":\"http://localhost:8080/api/v3/repos/<GITBUCKET_NAMESPACE>/git-repo\",\"http_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/git-repo.git\",\"clone_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/git-repo.git\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/git-repo\"}"
+        },
+        "headers": {
+          "Content-Length": "642",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:36 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/repos/<GITBUCKET_NAMESPACE>/git-repo"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_01_create__already_exists.json
+++ b/tests/integration/cassettes/test_gitbucket_test_01_create__already_exists.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:19",
+      "recorded_at": "2017-04-30T17:42:29",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,34 +17,34 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:19 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:29 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1t0htrr6dcqy7zaocy5rln907;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=v1gat922yeob3op8z3zdmrty;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     },
     {
-      "recorded_at": "2017-04-30T17:31:19",
+      "recorded_at": "2017-04-30T17:42:29",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"private\": false, \"has_downloads\": true, \"homepage\": \"\", \"name\": \"git-repo\", \"has_issues\": true, \"gitignore_template\": \"\", \"has_wiki\": true, \"description\": \"\", \"auto_init\": false}"
+          "string": "{\"homepage\": \"\", \"private\": false, \"has_wiki\": true, \"has_downloads\": true, \"name\": \"git-repo\", \"description\": \"\", \"gitignore_template\": \"\", \"has_issues\": true, \"auto_init\": false}"
         },
         "headers": {
           "Accept": "application/vnd.github.v3.full+json",
@@ -54,32 +54,32 @@
           "Connection": "keep-alive",
           "Content-Length": "180",
           "Content-Type": "application/json",
-          "Cookie": "JSESSIONID=1t0htrr6dcqy7zaocy5rln907",
+          "Cookie": "JSESSIONID=v1gat922yeob3op8z3zdmrty",
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "POST",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>/repos"
+        "uri": "http://localhost:8080/api/v3/user/repos"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"name\":\"git-repo\",\"full_name\":\"<GITBUCKET_NAMESPACE>/git-repo\",\"description\":\"\",\"watchers\":0,\"forks\":0,\"private\":false,\"default_branch\":\"master\",\"owner\":{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"},\"forks_count\":0,\"watchers_count\":0,\"url\":\"http://localhost:8080/api/v3/repos/<GITBUCKET_NAMESPACE>/git-repo\",\"http_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/git-repo.git\",\"clone_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/git-repo.git\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/git-repo\"}"
+          "string": "{\"name\":\"git-repo\",\"full_name\":\"<GITBUCKET_NAMESPACE>/git-repo\",\"description\":\"\",\"watchers\":0,\"forks\":0,\"private\":false,\"default_branch\":\"master\",\"owner\":{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"},\"forks_count\":0,\"watchers_count\":0,\"url\":\"http://localhost:8080/api/v3/repos/<GITBUCKET_NAMESPACE>/git-repo\",\"http_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/git-repo.git\",\"clone_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/git-repo.git\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/git-repo\"}"
         },
         "headers": {
-          "Content-Length": "642",
+          "Content-Length": "723",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:19 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:29 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>/repos"
+        "url": "http://localhost:8080/api/v3/user/repos"
       }
     },
     {
-      "recorded_at": "2017-04-30T17:31:20",
+      "recorded_at": "2017-04-30T17:42:30",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -92,7 +92,7 @@
           "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
           "Connection": "keep-alive",
           "Content-Type": "application/json",
-          "Cookie": "JSESSIONID=1t0htrr6dcqy7zaocy5rln907",
+          "Cookie": "JSESSIONID=v1gat922yeob3op8z3zdmrty",
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
@@ -101,12 +101,12 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"name\":\"git-repo\",\"full_name\":\"<GITBUCKET_NAMESPACE>/git-repo\",\"description\":\"\",\"watchers\":0,\"forks\":0,\"private\":false,\"default_branch\":\"master\",\"owner\":{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"},\"forks_count\":0,\"watchers_count\":0,\"url\":\"http://localhost:8080/api/v3/repos/<GITBUCKET_NAMESPACE>/git-repo\",\"http_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/git-repo.git\",\"clone_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/git-repo.git\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/git-repo\"}"
+          "string": "{\"name\":\"git-repo\",\"full_name\":\"<GITBUCKET_NAMESPACE>/git-repo\",\"description\":\"\",\"watchers\":0,\"forks\":0,\"private\":false,\"default_branch\":\"master\",\"owner\":{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"},\"forks_count\":0,\"watchers_count\":0,\"url\":\"http://localhost:8080/api/v3/repos/<GITBUCKET_NAMESPACE>/git-repo\",\"http_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/git-repo.git\",\"clone_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/git-repo.git\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/git-repo\"}"
         },
         "headers": {
-          "Content-Length": "642",
+          "Content-Length": "723",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:20 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:30 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)"
         },
         "status": {

--- a/tests/integration/cassettes/test_gitbucket_test_01_create__new.json
+++ b/tests/integration/cassettes/test_gitbucket_test_01_create__new.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:36",
+      "recorded_at": "2017-04-30T17:31:19",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:36 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:19 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=n2h07ygolzorkq3c2vyougty;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=f6f1lowcyagfvalbpqmxr3ef;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
@@ -40,11 +40,11 @@
       }
     },
     {
-      "recorded_at": "2017-04-30T17:11:36",
+      "recorded_at": "2017-04-30T17:31:19",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"description\": \"\", \"auto_init\": false, \"private\": false, \"has_downloads\": true, \"name\": \"foobar\", \"has_wiki\": true, \"has_issues\": true, \"gitignore_template\": \"\", \"homepage\": \"\"}"
+          "string": "{\"private\": false, \"has_downloads\": true, \"homepage\": \"\", \"name\": \"foobar\", \"has_issues\": true, \"gitignore_template\": \"\", \"has_wiki\": true, \"description\": \"\", \"auto_init\": false}"
         },
         "headers": {
           "Accept": "application/vnd.github.v3.full+json",
@@ -54,7 +54,7 @@
           "Connection": "keep-alive",
           "Content-Length": "178",
           "Content-Type": "application/json",
-          "Cookie": "JSESSIONID=n2h07ygolzorkq3c2vyougty",
+          "Cookie": "JSESSIONID=f6f1lowcyagfvalbpqmxr3ef",
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "POST",
@@ -63,12 +63,12 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"message\":\"A repository with this name already exists on this account\",\"documentation_url\":\"https://developer.github.com/v3/repos/#create\"}"
+          "string": "{\"name\":\"foobar\",\"full_name\":\"<GITBUCKET_NAMESPACE>/foobar\",\"description\":\"\",\"watchers\":0,\"forks\":0,\"private\":false,\"default_branch\":\"master\",\"owner\":{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"},\"forks_count\":0,\"watchers_count\":0,\"url\":\"http://localhost:8080/api/v3/repos/<GITBUCKET_NAMESPACE>/foobar\",\"http_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/foobar.git\",\"clone_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/foobar.git\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/foobar\"}"
         },
         "headers": {
-          "Content-Length": "140",
+          "Content-Length": "630",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:36 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:19 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)"
         },
         "status": {
@@ -79,7 +79,7 @@
       }
     },
     {
-      "recorded_at": "2017-04-30T17:11:36",
+      "recorded_at": "2017-04-30T17:31:19",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -92,7 +92,7 @@
           "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
           "Connection": "keep-alive",
           "Content-Type": "application/json",
-          "Cookie": "JSESSIONID=n2h07ygolzorkq3c2vyougty",
+          "Cookie": "JSESSIONID=f6f1lowcyagfvalbpqmxr3ef",
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
@@ -101,12 +101,12 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"name\":\"foobar\",\"full_name\":\"<GITBUCKET_NAMESPACE>/foobar\",\"description\":\"\",\"watchers\":0,\"forks\":0,\"private\":false,\"default_branch\":\"master\",\"owner\":{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"},\"forks_count\":0,\"watchers_count\":0,\"url\":\"http://localhost:8080/api/v3/repos/<GITBUCKET_NAMESPACE>/foobar\",\"http_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/foobar.git\",\"clone_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/foobar.git\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/foobar\"}"
+          "string": "{\"name\":\"foobar\",\"full_name\":\"<GITBUCKET_NAMESPACE>/foobar\",\"description\":\"\",\"watchers\":0,\"forks\":0,\"private\":false,\"default_branch\":\"master\",\"owner\":{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"},\"forks_count\":0,\"watchers_count\":0,\"url\":\"http://localhost:8080/api/v3/repos/<GITBUCKET_NAMESPACE>/foobar\",\"http_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/foobar.git\",\"clone_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/foobar.git\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/foobar\"}"
         },
         "headers": {
           "Content-Length": "630",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:36 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:19 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)"
         },
         "status": {

--- a/tests/integration/cassettes/test_gitbucket_test_01_create__new.json
+++ b/tests/integration/cassettes/test_gitbucket_test_01_create__new.json
@@ -1,0 +1,121 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:36 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=n2h07ygolzorkq3c2vyougty;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    },
+    {
+      "recorded_at": "2017-04-30T17:11:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"description\": \"\", \"auto_init\": false, \"private\": false, \"has_downloads\": true, \"name\": \"foobar\", \"has_wiki\": true, \"has_issues\": true, \"gitignore_template\": \"\", \"homepage\": \"\"}"
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Length": "178",
+          "Content-Type": "application/json",
+          "Cookie": "JSESSIONID=n2h07ygolzorkq3c2vyougty",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "POST",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>/repos"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"message\":\"A repository with this name already exists on this account\",\"documentation_url\":\"https://developer.github.com/v3/repos/#create\"}"
+        },
+        "headers": {
+          "Content-Length": "140",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:36 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>/repos"
+      }
+    },
+    {
+      "recorded_at": "2017-04-30T17:11:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "Cookie": "JSESSIONID=n2h07ygolzorkq3c2vyougty",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/repos/<GITBUCKET_NAMESPACE>/foobar"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"name\":\"foobar\",\"full_name\":\"<GITBUCKET_NAMESPACE>/foobar\",\"description\":\"\",\"watchers\":0,\"forks\":0,\"private\":false,\"default_branch\":\"master\",\"owner\":{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"},\"forks_count\":0,\"watchers_count\":0,\"url\":\"http://localhost:8080/api/v3/repos/<GITBUCKET_NAMESPACE>/foobar\",\"http_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/foobar.git\",\"clone_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/foobar.git\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/foobar\"}"
+        },
+        "headers": {
+          "Content-Length": "630",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:36 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/repos/<GITBUCKET_NAMESPACE>/foobar"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_01_create__new.json
+++ b/tests/integration/cassettes/test_gitbucket_test_01_create__new.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:19",
+      "recorded_at": "2017-04-30T17:42:28",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,34 +17,34 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:19 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:28 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=f6f1lowcyagfvalbpqmxr3ef;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1qov5cklqgs4e1csa4msfppabx;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     },
     {
-      "recorded_at": "2017-04-30T17:31:19",
+      "recorded_at": "2017-04-30T17:42:29",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"private\": false, \"has_downloads\": true, \"homepage\": \"\", \"name\": \"foobar\", \"has_issues\": true, \"gitignore_template\": \"\", \"has_wiki\": true, \"description\": \"\", \"auto_init\": false}"
+          "string": "{\"homepage\": \"\", \"private\": false, \"has_wiki\": true, \"has_downloads\": true, \"name\": \"foobar\", \"description\": \"\", \"gitignore_template\": \"\", \"has_issues\": true, \"auto_init\": false}"
         },
         "headers": {
           "Accept": "application/vnd.github.v3.full+json",
@@ -54,32 +54,32 @@
           "Connection": "keep-alive",
           "Content-Length": "178",
           "Content-Type": "application/json",
-          "Cookie": "JSESSIONID=f6f1lowcyagfvalbpqmxr3ef",
+          "Cookie": "JSESSIONID=1qov5cklqgs4e1csa4msfppabx",
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "POST",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>/repos"
+        "uri": "http://localhost:8080/api/v3/user/repos"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"name\":\"foobar\",\"full_name\":\"<GITBUCKET_NAMESPACE>/foobar\",\"description\":\"\",\"watchers\":0,\"forks\":0,\"private\":false,\"default_branch\":\"master\",\"owner\":{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"},\"forks_count\":0,\"watchers_count\":0,\"url\":\"http://localhost:8080/api/v3/repos/<GITBUCKET_NAMESPACE>/foobar\",\"http_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/foobar.git\",\"clone_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/foobar.git\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/foobar\"}"
+          "string": "{\"name\":\"foobar\",\"full_name\":\"<GITBUCKET_NAMESPACE>/foobar\",\"description\":\"\",\"watchers\":0,\"forks\":0,\"private\":false,\"default_branch\":\"master\",\"owner\":{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"},\"forks_count\":0,\"watchers_count\":0,\"url\":\"http://localhost:8080/api/v3/repos/<GITBUCKET_NAMESPACE>/foobar\",\"http_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/foobar.git\",\"clone_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/foobar.git\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/foobar\"}"
         },
         "headers": {
-          "Content-Length": "630",
+          "Content-Length": "711",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:19 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:28 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>/repos"
+        "url": "http://localhost:8080/api/v3/user/repos"
       }
     },
     {
-      "recorded_at": "2017-04-30T17:31:19",
+      "recorded_at": "2017-04-30T17:42:29",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -92,7 +92,7 @@
           "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
           "Connection": "keep-alive",
           "Content-Type": "application/json",
-          "Cookie": "JSESSIONID=f6f1lowcyagfvalbpqmxr3ef",
+          "Cookie": "JSESSIONID=1qov5cklqgs4e1csa4msfppabx",
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
@@ -101,12 +101,12 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"name\":\"foobar\",\"full_name\":\"<GITBUCKET_NAMESPACE>/foobar\",\"description\":\"\",\"watchers\":0,\"forks\":0,\"private\":false,\"default_branch\":\"master\",\"owner\":{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"},\"forks_count\":0,\"watchers_count\":0,\"url\":\"http://localhost:8080/api/v3/repos/<GITBUCKET_NAMESPACE>/foobar\",\"http_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/foobar.git\",\"clone_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/foobar.git\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/foobar\"}"
+          "string": "{\"name\":\"foobar\",\"full_name\":\"<GITBUCKET_NAMESPACE>/foobar\",\"description\":\"\",\"watchers\":0,\"forks\":0,\"private\":false,\"default_branch\":\"master\",\"owner\":{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"},\"forks_count\":0,\"watchers_count\":0,\"url\":\"http://localhost:8080/api/v3/repos/<GITBUCKET_NAMESPACE>/foobar\",\"http_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/foobar.git\",\"clone_url\":\"http://localhost:8080/git/<GITBUCKET_NAMESPACE>/foobar.git\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/foobar\"}"
         },
         "headers": {
-          "Content-Length": "630",
+          "Content-Length": "711",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:19 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:29 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)"
         },
         "status": {

--- a/tests/integration/cassettes/test_gitbucket_test_02_delete.json
+++ b/tests/integration/cassettes/test_gitbucket_test_02_delete.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:20",
+      "recorded_at": "2017-04-30T17:42:30",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:20 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:30 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1h1tnfg5vux8b1sr2m5v654ltb;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1exebz6q2dntt1fxo3txlh9yzx;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_02_delete.json
+++ b/tests/integration/cassettes/test_gitbucket_test_02_delete.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:37",
+      "recorded_at": "2017-04-30T17:31:20",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:37 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:20 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1vx1ev1zr95bzfaeao0tgb92p;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1h1tnfg5vux8b1sr2m5v654ltb;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_02_delete.json
+++ b/tests/integration/cassettes/test_gitbucket_test_02_delete.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:37",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:37 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=1vx1ev1zr95bzfaeao0tgb92p;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_03_delete_nouser.json
+++ b/tests/integration/cassettes/test_gitbucket_test_03_delete_nouser.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:37",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:37 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=1rzzvel8qbcxdas0sholvfxl1;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_03_delete_nouser.json
+++ b/tests/integration/cassettes/test_gitbucket_test_03_delete_nouser.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:37",
+      "recorded_at": "2017-04-30T17:31:20",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:37 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:20 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1rzzvel8qbcxdas0sholvfxl1;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1w4ykif4lsm181mi3ytvw4fe9w;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_03_delete_nouser.json
+++ b/tests/integration/cassettes/test_gitbucket_test_03_delete_nouser.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:20",
+      "recorded_at": "2017-04-30T17:42:30",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:20 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:30 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1w4ykif4lsm181mi3ytvw4fe9w;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1g702abps6zwe13t5bf4zuxwj4;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_04_clone.json
+++ b/tests/integration/cassettes/test_gitbucket_test_04_clone.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:20",
+      "recorded_at": "2017-04-30T17:42:30",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:20 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:30 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=19n5qwdalb9q3ymed928jykk0;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1t9d5a78pxryvgv4iq8sz0azm;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_04_clone.json
+++ b/tests/integration/cassettes/test_gitbucket_test_04_clone.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:37",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:37 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=o6qmuj1hg3npbnfe7yckqj3y;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_04_clone.json
+++ b/tests/integration/cassettes/test_gitbucket_test_04_clone.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:37",
+      "recorded_at": "2017-04-30T17:31:20",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:37 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:20 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=o6qmuj1hg3npbnfe7yckqj3y;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=19n5qwdalb9q3ymed928jykk0;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_05_add.json
+++ b/tests/integration/cassettes/test_gitbucket_test_05_add.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:21",
+      "recorded_at": "2017-04-30T17:42:31",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:21 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:31 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=123c9wzqkd2qo1ax8pek24hqdf;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=12fqq4ah6d7rv5zzoig6ip5kz;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_05_add.json
+++ b/tests/integration/cassettes/test_gitbucket_test_05_add.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:38",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:38 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=1x5joczfhcq261fry29nm4qkr;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_05_add.json
+++ b/tests/integration/cassettes/test_gitbucket_test_05_add.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:38",
+      "recorded_at": "2017-04-30T17:31:21",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:38 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:21 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1x5joczfhcq261fry29nm4qkr;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=123c9wzqkd2qo1ax8pek24hqdf;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_06_add__name.json
+++ b/tests/integration/cassettes/test_gitbucket_test_06_add__name.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:38",
+      "recorded_at": "2017-04-30T17:31:21",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:38 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:21 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=dit59jbbvdz91krjmthrlbdoh;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1vczt0awja9ez10iqbmzz7yryy;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_06_add__name.json
+++ b/tests/integration/cassettes/test_gitbucket_test_06_add__name.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:38",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:38 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=dit59jbbvdz91krjmthrlbdoh;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_06_add__name.json
+++ b/tests/integration/cassettes/test_gitbucket_test_06_add__name.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:21",
+      "recorded_at": "2017-04-30T17:42:31",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:21 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:31 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1vczt0awja9ez10iqbmzz7yryy;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=xi2pyzrjgpyz1ekggbnj8jgn1;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_07_add__alone.json
+++ b/tests/integration/cassettes/test_gitbucket_test_07_add__alone.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:39",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:39 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=1vtkxla3z42by50gvcjwslg87;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_07_add__alone.json
+++ b/tests/integration/cassettes/test_gitbucket_test_07_add__alone.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:22",
+      "recorded_at": "2017-04-30T17:42:32",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:22 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:32 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1xvmxwggub6c41ivumiw9s0pa7;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1i160yq1tpaxc1ob0onmmj0iw5;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_07_add__alone.json
+++ b/tests/integration/cassettes/test_gitbucket_test_07_add__alone.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:39",
+      "recorded_at": "2017-04-30T17:31:22",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:39 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:22 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1vtkxla3z42by50gvcjwslg87;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1xvmxwggub6c41ivumiw9s0pa7;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_08_add__alone_name.json
+++ b/tests/integration/cassettes/test_gitbucket_test_08_add__alone_name.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:39",
+      "recorded_at": "2017-04-30T17:31:22",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:39 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:22 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=12rrvx3zcj44xyaduvjl6jx22;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=w2ip0yfq5jgz2qjkju9fe8dp;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_08_add__alone_name.json
+++ b/tests/integration/cassettes/test_gitbucket_test_08_add__alone_name.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:39",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:39 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=12rrvx3zcj44xyaduvjl6jx22;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_08_add__alone_name.json
+++ b/tests/integration/cassettes/test_gitbucket_test_08_add__alone_name.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:22",
+      "recorded_at": "2017-04-30T17:42:32",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:22 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:32 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=w2ip0yfq5jgz2qjkju9fe8dp;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1j5abn2kogqvt1qlk2sm7efyhk;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_09_add__default.json
+++ b/tests/integration/cassettes/test_gitbucket_test_09_add__default.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:40",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:40 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=10k8wokxp2mo5zvb7vyof4xem;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_09_add__default.json
+++ b/tests/integration/cassettes/test_gitbucket_test_09_add__default.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:22",
+      "recorded_at": "2017-04-30T17:42:33",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:22 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:33 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1g3z7azsg5xep1033p5es2bb0o;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=16txux2n20esxcq0ycl4ibyfy;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_09_add__default.json
+++ b/tests/integration/cassettes/test_gitbucket_test_09_add__default.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:40",
+      "recorded_at": "2017-04-30T17:31:22",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:40 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:22 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=10k8wokxp2mo5zvb7vyof4xem;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1g3z7azsg5xep1033p5es2bb0o;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_10_add__default_name.json
+++ b/tests/integration/cassettes/test_gitbucket_test_10_add__default_name.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:40",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:40 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=1lr4rvi26jbjb20dyrd6efa0i;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_10_add__default_name.json
+++ b/tests/integration/cassettes/test_gitbucket_test_10_add__default_name.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:40",
+      "recorded_at": "2017-04-30T17:31:23",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:40 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:23 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1lr4rvi26jbjb20dyrd6efa0i;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1ctz8v9uta4ur1rkfpv29i91cs;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_10_add__default_name.json
+++ b/tests/integration/cassettes/test_gitbucket_test_10_add__default_name.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:23",
+      "recorded_at": "2017-04-30T17:42:33",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:23 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:33 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1ctz8v9uta4ur1rkfpv29i91cs;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1hqliraoevl171wgt4h7z399tb;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_11_add__alone_default.json
+++ b/tests/integration/cassettes/test_gitbucket_test_11_add__alone_default.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:41",
+      "recorded_at": "2017-04-30T17:31:23",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:41 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:23 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1x8hcqmp9vaqd68k0byyj6p7r;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=y1pi43ld22lr1x6xby8s2fe8h;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_11_add__alone_default.json
+++ b/tests/integration/cassettes/test_gitbucket_test_11_add__alone_default.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:41",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:41 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=1x8hcqmp9vaqd68k0byyj6p7r;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_11_add__alone_default.json
+++ b/tests/integration/cassettes/test_gitbucket_test_11_add__alone_default.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:23",
+      "recorded_at": "2017-04-30T17:42:34",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:23 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:34 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=y1pi43ld22lr1x6xby8s2fe8h;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=17t18c8pftcot13bjwzburvb7l;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_12_add__alone_default_name.json
+++ b/tests/integration/cassettes/test_gitbucket_test_12_add__alone_default_name.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:42",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:42 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=17764gkyb5jze1w4pbkcry96ww;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_12_add__alone_default_name.json
+++ b/tests/integration/cassettes/test_gitbucket_test_12_add__alone_default_name.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:42",
+      "recorded_at": "2017-04-30T17:31:24",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:42 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:24 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=17764gkyb5jze1w4pbkcry96ww;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=itd2iapwyb7l1dvrl7z9idgwn;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_12_add__alone_default_name.json
+++ b/tests/integration/cassettes/test_gitbucket_test_12_add__alone_default_name.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:24",
+      "recorded_at": "2017-04-30T17:42:34",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:24 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:34 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=itd2iapwyb7l1dvrl7z9idgwn;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1m9vstsyir60d88al5xcy0t4h;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_13_gist_list.json
+++ b/tests/integration/cassettes/test_gitbucket_test_13_gist_list.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:24",
+      "recorded_at": "2017-04-30T17:42:35",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:24 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:35 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=ngmkd6ni3rp71ecdv1wa4odub;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=19cj7kzolpoz11jfvpg3aftrlb;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_13_gist_list.json
+++ b/tests/integration/cassettes/test_gitbucket_test_13_gist_list.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:42",
+      "recorded_at": "2017-04-30T17:31:24",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:42 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:24 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1bfdv5r0ngemstumliz04scry;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=ngmkd6ni3rp71ecdv1wa4odub;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_13_gist_list.json
+++ b/tests/integration/cassettes/test_gitbucket_test_13_gist_list.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:42",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:42 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=1bfdv5r0ngemstumliz04scry;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_14_gist_list_with_gist.json
+++ b/tests/integration/cassettes/test_gitbucket_test_14_gist_list_with_gist.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:42",
+      "recorded_at": "2017-04-30T17:31:24",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:42 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:24 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=11sc8c997tst41i8krwo94w0qs;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1t59yomabieqviwmwali4vkl1;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_14_gist_list_with_gist.json
+++ b/tests/integration/cassettes/test_gitbucket_test_14_gist_list_with_gist.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:24",
+      "recorded_at": "2017-04-30T17:42:35",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:24 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:35 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1t59yomabieqviwmwali4vkl1;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1jszig4mp93y31kykxoqtlm484;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_14_gist_list_with_gist.json
+++ b/tests/integration/cassettes/test_gitbucket_test_14_gist_list_with_gist.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:42",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:42 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=11sc8c997tst41i8krwo94w0qs;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_15_gist_list_with_bad_gist.json
+++ b/tests/integration/cassettes/test_gitbucket_test_15_gist_list_with_bad_gist.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:43",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:43 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=uzvavtzhoaurhkg9ilvxwz0h;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_15_gist_list_with_bad_gist.json
+++ b/tests/integration/cassettes/test_gitbucket_test_15_gist_list_with_bad_gist.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:24",
+      "recorded_at": "2017-04-30T17:42:36",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:24 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:36 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=ze37ehtep0xl1v42yz39ak6iv;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1wi4fpto9cfsv5tw9ks1hsx4j;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_15_gist_list_with_bad_gist.json
+++ b/tests/integration/cassettes/test_gitbucket_test_15_gist_list_with_bad_gist.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:43",
+      "recorded_at": "2017-04-30T17:31:24",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:43 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:24 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=uzvavtzhoaurhkg9ilvxwz0h;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=ze37ehtep0xl1v42yz39ak6iv;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_16_gist_clone_with_gist.json
+++ b/tests/integration/cassettes/test_gitbucket_test_16_gist_clone_with_gist.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:24",
+      "recorded_at": "2017-04-30T17:42:36",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:24 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:36 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=2r2a5rp2ar01dbf7ojwupio6;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1xi71cp1fw2c116p6uod3kcyut;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_16_gist_clone_with_gist.json
+++ b/tests/integration/cassettes/test_gitbucket_test_16_gist_clone_with_gist.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:43",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:43 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=1lj5zfwn9vkuvowgc0e0so6d0;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_16_gist_clone_with_gist.json
+++ b/tests/integration/cassettes/test_gitbucket_test_16_gist_clone_with_gist.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:43",
+      "recorded_at": "2017-04-30T17:31:24",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:43 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:24 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1lj5zfwn9vkuvowgc0e0so6d0;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=2r2a5rp2ar01dbf7ojwupio6;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_17_gist_fetch_with_gist.json
+++ b/tests/integration/cassettes/test_gitbucket_test_17_gist_fetch_with_gist.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:43",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:43 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=1jmr6q70uzmevoq2hi1iublvb;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_17_gist_fetch_with_gist.json
+++ b/tests/integration/cassettes/test_gitbucket_test_17_gist_fetch_with_gist.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:43",
+      "recorded_at": "2017-04-30T17:31:24",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:43 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:24 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1jmr6q70uzmevoq2hi1iublvb;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=113shbf7vmq0js1v6llfc5k6o;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_17_gist_fetch_with_gist.json
+++ b/tests/integration/cassettes/test_gitbucket_test_17_gist_fetch_with_gist.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:24",
+      "recorded_at": "2017-04-30T17:42:36",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:24 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:36 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=113shbf7vmq0js1v6llfc5k6o;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1gcpynd4mn3xpedqf40o45uz3;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_18_gist_fetch_with_bad_gist.json
+++ b/tests/integration/cassettes/test_gitbucket_test_18_gist_fetch_with_bad_gist.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:43",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:43 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=1e8u21b2o7z8z13v90elxx2jh1;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_18_gist_fetch_with_bad_gist.json
+++ b/tests/integration/cassettes/test_gitbucket_test_18_gist_fetch_with_bad_gist.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:43",
+      "recorded_at": "2017-04-30T17:31:25",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:43 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:25 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1e8u21b2o7z8z13v90elxx2jh1;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1oia6o25oods6bbn3omgy8j9r;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_18_gist_fetch_with_bad_gist.json
+++ b/tests/integration/cassettes/test_gitbucket_test_18_gist_fetch_with_bad_gist.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:25",
+      "recorded_at": "2017-04-30T17:42:37",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:25 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:37 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1oia6o25oods6bbn3omgy8j9r;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=xfbfqxcodsx1wr5637fl5m3e;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_19_gist_fetch_with_gist_file.json
+++ b/tests/integration/cassettes/test_gitbucket_test_19_gist_fetch_with_gist_file.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:25",
+      "recorded_at": "2017-04-30T17:42:37",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:25 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:37 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=erudbbqavk4t1pd3xfdsglqdn;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=26n6v4rhipg7ndacpsgvsdup;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_19_gist_fetch_with_gist_file.json
+++ b/tests/integration/cassettes/test_gitbucket_test_19_gist_fetch_with_gist_file.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:44",
+      "recorded_at": "2017-04-30T17:31:25",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:44 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:25 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1dogfcf23m52z1s2ws6dcjoz7p;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=erudbbqavk4t1pd3xfdsglqdn;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_19_gist_fetch_with_gist_file.json
+++ b/tests/integration/cassettes/test_gitbucket_test_19_gist_fetch_with_gist_file.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:44",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:44 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=1dogfcf23m52z1s2ws6dcjoz7p;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_20_gist_fetch_with_bad_gist_file.json
+++ b/tests/integration/cassettes/test_gitbucket_test_20_gist_fetch_with_bad_gist_file.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:44",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:44 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=2p75v1i18ug6u6q44cforlja;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_20_gist_fetch_with_bad_gist_file.json
+++ b/tests/integration/cassettes/test_gitbucket_test_20_gist_fetch_with_bad_gist_file.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:44",
+      "recorded_at": "2017-04-30T17:31:25",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:44 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:25 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=2p75v1i18ug6u6q44cforlja;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=16tqlmz4u51iy1wy6ali1djwsy;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_20_gist_fetch_with_bad_gist_file.json
+++ b/tests/integration/cassettes/test_gitbucket_test_20_gist_fetch_with_bad_gist_file.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:25",
+      "recorded_at": "2017-04-30T17:42:37",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:25 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:37 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=16tqlmz4u51iy1wy6ali1djwsy;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=107eb5tuzrg3y5lb1qz8ecwkj;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_21_gist_create_gist_file.json
+++ b/tests/integration/cassettes/test_gitbucket_test_21_gist_create_gist_file.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:44",
+      "recorded_at": "2017-04-30T17:31:25",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:44 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:25 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=149wvw8j9lcjpwirqfnvxs441;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=dp6qp7l5wv9tp4kzhbeu3f1v;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_21_gist_create_gist_file.json
+++ b/tests/integration/cassettes/test_gitbucket_test_21_gist_create_gist_file.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:25",
+      "recorded_at": "2017-04-30T17:42:38",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:25 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:38 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=dp6qp7l5wv9tp4kzhbeu3f1v;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1eo8n83wolqkf111jlwg4o8di;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_21_gist_create_gist_file.json
+++ b/tests/integration/cassettes/test_gitbucket_test_21_gist_create_gist_file.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:44",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:44 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=149wvw8j9lcjpwirqfnvxs441;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_22_gist_create_gist_file_list.json
+++ b/tests/integration/cassettes/test_gitbucket_test_22_gist_create_gist_file_list.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:25",
+      "recorded_at": "2017-04-30T17:42:38",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:25 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:38 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=lxog2brauk9p1w7nftvnd8om;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=cpr24yfr94sm19vtbt1smehv3;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_22_gist_create_gist_file_list.json
+++ b/tests/integration/cassettes/test_gitbucket_test_22_gist_create_gist_file_list.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:45",
+      "recorded_at": "2017-04-30T17:31:25",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:45 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:25 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1txp5ub6trtrp1sxk5yqff38s2;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=lxog2brauk9p1w7nftvnd8om;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_22_gist_create_gist_file_list.json
+++ b/tests/integration/cassettes/test_gitbucket_test_22_gist_create_gist_file_list.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:45",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:45 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=1txp5ub6trtrp1sxk5yqff38s2;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_23_gist_create_gist_dir.json
+++ b/tests/integration/cassettes/test_gitbucket_test_23_gist_create_gist_dir.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:26",
+      "recorded_at": "2017-04-30T17:42:39",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:26 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:39 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=htd0sqtenvrm1kvmpdrnxt8dm;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=6r3ac49phphb1dopjgfhmlzxo;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_23_gist_create_gist_dir.json
+++ b/tests/integration/cassettes/test_gitbucket_test_23_gist_create_gist_dir.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:45",
+      "recorded_at": "2017-04-30T17:31:26",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:45 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:26 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1nw8d8wwks9bc1v2ptknep12o;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=htd0sqtenvrm1kvmpdrnxt8dm;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_23_gist_create_gist_dir.json
+++ b/tests/integration/cassettes/test_gitbucket_test_23_gist_create_gist_dir.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:45",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:45 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=1nw8d8wwks9bc1v2ptknep12o;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_24_gist_create_gist_file.json
+++ b/tests/integration/cassettes/test_gitbucket_test_24_gist_create_gist_file.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:45",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:45 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=qqky2r3k7rcm125jrctfhfoz2;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_24_gist_create_gist_file.json
+++ b/tests/integration/cassettes/test_gitbucket_test_24_gist_create_gist_file.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:26",
+      "recorded_at": "2017-04-30T17:42:39",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:26 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:39 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1jeol6v57uzn61n6o0j1yprrgt;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=lgjbyilel85bcvicib1nze0b;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_24_gist_create_gist_file.json
+++ b/tests/integration/cassettes/test_gitbucket_test_24_gist_create_gist_file.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:45",
+      "recorded_at": "2017-04-30T17:31:26",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:45 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:26 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=qqky2r3k7rcm125jrctfhfoz2;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1jeol6v57uzn61n6o0j1yprrgt;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_25_gist_create_gist_file_list.json
+++ b/tests/integration/cassettes/test_gitbucket_test_25_gist_create_gist_file_list.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:46",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:46 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=zurybc71dblk1uio44spnak2h;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_25_gist_create_gist_file_list.json
+++ b/tests/integration/cassettes/test_gitbucket_test_25_gist_create_gist_file_list.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:26",
+      "recorded_at": "2017-04-30T17:42:39",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:26 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:39 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=nvvyuaitdxfg1xk30m3hiqufg;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1tlbrlyyzscxymgfq357ruezz;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_25_gist_create_gist_file_list.json
+++ b/tests/integration/cassettes/test_gitbucket_test_25_gist_create_gist_file_list.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:46",
+      "recorded_at": "2017-04-30T17:31:26",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:46 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:26 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=zurybc71dblk1uio44spnak2h;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=nvvyuaitdxfg1xk30m3hiqufg;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_26_gist_create_gist_dir.json
+++ b/tests/integration/cassettes/test_gitbucket_test_26_gist_create_gist_dir.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:46",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:46 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=14n3aql2fvekhnvuhy6hrn2ti;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_26_gist_create_gist_dir.json
+++ b/tests/integration/cassettes/test_gitbucket_test_26_gist_create_gist_dir.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:26",
+      "recorded_at": "2017-04-30T17:42:40",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:26 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:40 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=c2jcyuzouede1b6lllfjkp30b;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=57ifzntem987y5m8j25y79tj;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_26_gist_create_gist_dir.json
+++ b/tests/integration/cassettes/test_gitbucket_test_26_gist_create_gist_dir.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:46",
+      "recorded_at": "2017-04-30T17:31:26",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:46 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:26 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=14n3aql2fvekhnvuhy6hrn2ti;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=c2jcyuzouede1b6lllfjkp30b;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_27_gist_delete.json
+++ b/tests/integration/cassettes/test_gitbucket_test_27_gist_delete.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:26",
+      "recorded_at": "2017-04-30T17:42:40",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:26 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:40 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=12eyc2cowhj6a1js6azbqm6lm5;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1da8sni02eukg17e15zmbn004y;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_27_gist_delete.json
+++ b/tests/integration/cassettes/test_gitbucket_test_27_gist_delete.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:46",
+      "recorded_at": "2017-04-30T17:31:26",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:46 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:26 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=b1o40r1lodov1icwch6o9f31u;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=12eyc2cowhj6a1js6azbqm6lm5;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_27_gist_delete.json
+++ b/tests/integration/cassettes/test_gitbucket_test_27_gist_delete.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:46",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:46 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=b1o40r1lodov1icwch6o9f31u;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_28_gist_delete__not_exist.json
+++ b/tests/integration/cassettes/test_gitbucket_test_28_gist_delete__not_exist.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:47 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=o7nz9tfje5041c9vahvb4dscj;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/cassettes/test_gitbucket_test_28_gist_delete__not_exist.json
+++ b/tests/integration/cassettes/test_gitbucket_test_28_gist_delete__not_exist.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:26",
+      "recorded_at": "2017-04-30T17:42:41",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:26 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:41 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=irywvc2oznvn11q765j13otrx;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=yr4lxlpbi9rpsjaw1a2qnwzt;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_28_gist_delete__not_exist.json
+++ b/tests/integration/cassettes/test_gitbucket_test_28_gist_delete__not_exist.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:47",
+      "recorded_at": "2017-04-30T17:31:26",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:47 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:26 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=o7nz9tfje5041c9vahvb4dscj;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=irywvc2oznvn11q765j13otrx;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_29_gist_create_gist__file_not_exist.json
+++ b/tests/integration/cassettes/test_gitbucket_test_29_gist_create_gist__file_not_exist.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:11:47",
+      "recorded_at": "2017-04-30T17:31:27",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,15 +22,15 @@
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
           "Content-Length": "248",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:11:47 GMT",
+          "Date": "Sun, 30 Apr 2017 17:31:27 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=1jsr9t5wx30jysiictq4wf419;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=ga4tikqfqx7n6d9llwfq5rq1;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,

--- a/tests/integration/cassettes/test_gitbucket_test_29_gist_create_gist__file_not_exist.json
+++ b/tests/integration/cassettes/test_gitbucket_test_29_gist_create_gist__file_not_exist.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-04-30T17:31:27",
+      "recorded_at": "2017-04-30T17:42:41",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -17,26 +17,26 @@
           "User-Agent": "github3.py/0.9.5"
         },
         "method": "GET",
-        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "uri": "http://localhost:8080/api/v3/user"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:30:44Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"user@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T17:39:36Z\",\"url\":\"http://localhost:8080/api/v3/users/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
         },
         "headers": {
-          "Content-Length": "248",
+          "Content-Length": "284",
           "Content-Type": "application/json;charset=utf-8",
-          "Date": "Sun, 30 Apr 2017 17:31:27 GMT",
+          "Date": "Sun, 30 Apr 2017 17:42:41 GMT",
           "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
           "Server": "Jetty(9.3.z-SNAPSHOT)",
-          "Set-Cookie": "JSESSIONID=ga4tikqfqx7n6d9llwfq5rq1;Path=/;HttpOnly"
+          "Set-Cookie": "JSESSIONID=1pauj5lksfgqw1054nf81qyr41;Path=/;HttpOnly"
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+        "url": "http://localhost:8080/api/v3/user"
       }
     }
   ],

--- a/tests/integration/cassettes/test_gitbucket_test_29_gist_create_gist__file_not_exist.json
+++ b/tests/integration/cassettes/test_gitbucket_test_29_gist_create_gist__file_not_exist.json
@@ -1,0 +1,44 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-30T17:11:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "application/vnd.github.v3.full+json",
+          "Accept-Charset": "utf-8",
+          "Accept-Encoding": "identity",
+          "Authorization": "token <PRIVATE_KEY_GITBUCKET>",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json",
+          "User-Agent": "github3.py/0.9.5"
+        },
+        "method": "GET",
+        "uri": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"login\":\"<GITBUCKET_NAMESPACE>\",\"email\":\"<GITBUCKET_NAMESPACE>@localhost\",\"type\":\"User\",\"site_admin\":false,\"created_at\":\"2017-04-30T15:09:05Z\",\"url\":\"http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>s/<GITBUCKET_NAMESPACE>\",\"html_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>\",\"avatar_url\":\"http://localhost:8080/<GITBUCKET_NAMESPACE>/_avatar\"}"
+        },
+        "headers": {
+          "Content-Length": "248",
+          "Content-Type": "application/json;charset=utf-8",
+          "Date": "Sun, 30 Apr 2017 17:11:47 GMT",
+          "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+          "Server": "Jetty(9.3.z-SNAPSHOT)",
+          "Set-Cookie": "JSESSIONID=1jsr9t5wx30jysiictq4wf419;Path=/;HttpOnly"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://localhost:8080/api/v3/<GITBUCKET_NAMESPACE>"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/integration/local/gitbucket/README.md
+++ b/tests/integration/local/gitbucket/README.md
@@ -1,0 +1,11 @@
+## Steps to running GitBucket
+
+- download gitbucket.war from https://github.com/gitbucket/gitbucket/releases. (tested version is 4.12)
+- run `java -jar gitbucket.war`
+    - It listen on 8080 port.
+    - It creates data directory to ~/.gitbucket
+    - There is only admin user by id:root / pw:root
+
+## Steps to initialize GitBucket data. 
+
+- run `python3 init.py`

--- a/tests/integration/local/gitbucket/init.py
+++ b/tests/integration/local/gitbucket/init.py
@@ -11,6 +11,20 @@ s = requests.Session()
 s.get(base_url + '/signin?redirect=%2F')
 s.post(base_url + '/signin', data={"userName": "root", "password": "root"})
 
+# start ssh server
+system_data = {
+    "baseUrl": "http://localhost:8080",
+    "information": "",
+    "allowAccountRegistration": "false",
+    "isCreateRepoOptionPublic": "true",
+    "allowAnonymousAccess": "true",
+    "activityLogLimit": "",
+    "ssh": "on",
+    "sshHost": "localhost",
+    "sshPort": "29418",
+}
+s.post(base_url + '/admin/system', data=system_data)
+
 # create test user
 user_data = {
     "userName": "user",

--- a/tests/integration/local/gitbucket/init.py
+++ b/tests/integration/local/gitbucket/init.py
@@ -27,9 +27,9 @@ s.post(base_url + '/admin/system', data=system_data)
 
 # create test user
 user_data = {
-    "userName": "user",
+    "userName": "git-repo-user",
     "password": "user",
-    "fullName": "user",
+    "fullName": "git-repo-user",
     "mailAddress": "user@localhost"
 }
 s.post(base_url + '/admin/users/_newuser', data=user_data)
@@ -49,19 +49,19 @@ s.get(base_url + '/signout')
 
 # sign in by user
 s.get(base_url + '/signin?redirect=%2F')
-s.post(base_url + '/signin', data={"userName": "user", "password": "user"})
+s.post(base_url + '/signin', data={"userName": "git-repo-user", "password": "user"})
 
 # create group
 group_data ={
     "groupName": "group",
     "description": "",
-    "memberName": "user",
-    "members": "user:true"
+    "memberName": "git-repo-user",
+    "members": "git-repo-user:true"
 }
 s.post(base_url + '/groups/new', data=group_data)
 
 # create Token
-ret = s.post(base_url + '/user/_personalToken', data={"note": "for test"})
+ret = s.post(base_url + '/git-repo-user/_personalToken', data={"note": "for test"})
 html = ret.content.decode("utf-8")
 find_text = "data-clipboard-text="
 idx = html.find(find_text) + len(find_text) + 1

--- a/tests/integration/local/gitbucket/init.py
+++ b/tests/integration/local/gitbucket/init.py
@@ -53,5 +53,5 @@ find_text = "data-clipboard-text="
 idx = html.find(find_text) + len(find_text) + 1
 token = html[idx:idx + 40]
 
-print("GITBUCKET_USER_TOKEN={}".format(token))
+print("PRIVATE_KEY_GITBUCKET={}".format(token))
 

--- a/tests/integration/local/gitbucket/init.py
+++ b/tests/integration/local/gitbucket/init.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import requests
+
+base_url = 'http://localhost:8080'
+
+s = requests.Session()
+
+# Sign in
+s.get(base_url + '/signin?redirect=%2F')
+s.post(base_url + '/signin', data={"userName": "root", "password": "root"})
+
+# create test user
+user_data = {
+    "userName": "user",
+    "password": "user",
+    "fullName": "user",
+    "mailAddress": "user@localhost"
+}
+s.post(base_url + '/admin/users/_newuser', data=user_data)
+
+# create root repo
+repo_data = {
+    "owner": "root",
+    "name": "repo",
+    "description": "",
+    "isPrivate": "false",
+    "createReadme": "on"
+}
+s.post(base_url + '/new', data=repo_data)
+
+# sign out
+s.get(base_url + '/signout')
+
+# sign in by user
+s.get(base_url + '/signin?redirect=%2F')
+s.post(base_url + '/signin', data={"userName": "user", "password": "user"})
+
+# create group
+group_data ={
+    "groupName": "group",
+    "description": "",
+    "memberName": "user",
+    "members": "user:true"
+}
+s.post(base_url + '/groups/new', data=group_data)
+
+# create Token
+ret = s.post(base_url + '/user/_personalToken', data={"note": "for test"})
+html = ret.content.decode("utf-8")
+find_text = "data-clipboard-text="
+idx = html.find(find_text) + len(find_text) + 1
+token = html[idx:idx + 40]
+
+print("GITBUCKET_USER_TOKEN={}".format(token))
+

--- a/tests/integration/test_gitbucket.py
+++ b/tests/integration/test_gitbucket.py
@@ -28,7 +28,7 @@ class Test_Gitbucket(GitRepoTestCase):
     def local_namespace(self):
         if 'GITBUCKET_NAMESPACE' in os.environ:
             return os.environ['GITBUCKET_NAMESPACE']
-        return 'user'
+        return 'git-repo-user'
 
     def get_service(self):
         return gitbucket.GitbucketService(c={

--- a/tests/integration/test_gitbucket.py
+++ b/tests/integration/test_gitbucket.py
@@ -44,28 +44,34 @@ class Test_Gitbucket(GitRepoTestCase):
         return self.service.gh._session
 
     def test_00_fork(self):
-        self.action_fork(local_namespace=self.local_namespace,
-                         remote_namespace='root',
-                         repository='repo')
+        # AttributeError occurs, because GitBucket doesn't support repos/forks API.
+        with pytest.raises(AttributeError):
+            self.action_fork(local_namespace=self.local_namespace,
+                             remote_namespace='root',
+                             repository='repo')
 
     def test_01_create__new(self):
         self.action_create(namespace=self.local_namespace,
                            repository='foobar')
 
     def test_01_create__already_exists(self):
-        with pytest.raises(ResourceExistsError):
-            self.action_create(namespace=self.local_namespace,
-                            repository='git-repo')
+        # GitBucket doesn't return 422. it returns 200. maybe GitBucket's issue?
+        # with pytest.raises(ResourceExistsError):
+        self.action_create(namespace=self.local_namespace,
+                        repository='git-repo')
 
+    # skip because GitBucket doesn't support create group's repo by POST /api/v3/users/:org/repos
+    @pytest.mark.skip
     def test_01_create_organization__new(self):
         self.action_create(namespace='group',
                            repository='foobar')
 
+    # skip because GitBucket doesn't support create group's repo by POST /api/v3/users/:org/repos
+    @pytest.mark.skip
     def test_01_create_organization__already_exists(self):
         with pytest.raises(ResourceExistsError):
             self.action_create(namespace='group',
                             repository='git-repo')
-
 
     def test_02_delete(self):
         with pytest.raises(NotImplementedError):

--- a/tests/integration/test_gitbucket.py
+++ b/tests/integration/test_gitbucket.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import logging
+
+import pytest
+
+#################################################################################
+# Enable logging
+
+log = logging.getLogger('test.gitbucket')
+
+#################################################################################
+
+from tests.helpers import GitRepoTestCase
+
+from git_repo.services.service import gitbucket
+from git_repo.exceptions import ResourceExistsError, ResourceNotFoundError, ResourceError
+
+
+class Test_Gitbucket(GitRepoTestCase):
+    log = log
+    namespace = "user"
+
+    @property
+    def local_namespace(self):
+        return 'user'
+
+    def get_service(self):
+        return gitbucket.GitbucketService(c={
+            '__name__': 'gitrepo "gitbucket-test"',
+            'fqdn': "localhost",
+            'port': "8080",
+            'scheme': "http",
+            'insecure': 'yes',
+            'token': os.environ['GITBUCKET_TOKEN']
+            })
+
+    def get_requests_session(self):
+        return self.service.gh._session
+
+    def test_00_fork(self):
+        self.action_fork(local_namespace=self.local_namespace,
+                         remote_namespace='root',
+                         repository='repo')
+
+    def test_01_create__new(self):
+        self.action_create(namespace=self.local_namespace,
+                           repository='foobar')
+
+    def test_01_create__already_exists(self):
+        with pytest.raises(ResourceExistsError):
+            self.action_create(namespace=self.local_namespace,
+                            repository='git-repo')
+
+    def test_01_create_organization__new(self):
+        self.action_create(namespace='group',
+                           repository='foobar')
+
+    def test_01_create_organization__already_exists(self):
+        with pytest.raises(ResourceExistsError):
+            self.action_create(namespace='group',
+                            repository='git-repo')
+
+
+    def test_02_delete(self):
+        self.action_delete(namespace=self.local_namespace,
+                           repository='foobar')
+
+    def test_03_delete_nouser(self):
+        with pytest.raises(NotImplementedError):
+            self.action_delete(repository='github3.py')
+
+    def test_04_clone(self):
+        self.action_clone(namespace='root',
+                          repository='repo')
+
+    def test_05_add(self):
+        self.action_add(namespace='root',
+                        repository='repo')
+
+    def test_06_add__name(self):
+        self.action_add(namespace='root',
+                        repository='repo',
+                        name='test0r')
+
+    def test_07_add__alone(self):
+        self.action_add(namespace='root',
+                        repository='repo',
+                        alone=True)
+
+    def test_08_add__alone_name(self):
+        self.action_add(namespace='root',
+                        repository='repo',
+                        name='test0r',
+                        alone=True)
+
+    def test_09_add__default(self):
+        self.action_add(namespace='root',
+                        repository='repo',
+                        tracking='gitbucket')
+
+    def test_10_add__default_name(self):
+        self.action_add(namespace='root',
+                        repository='repo',
+                        name='test0r',
+                        tracking='gitbucket')
+
+    def test_11_add__alone_default(self):
+        self.action_add(namespace='root',
+                        repository='repo',
+                        alone=True,
+                        tracking='gitbucket')
+
+    def test_12_add__alone_default_name(self):
+        self.action_add(namespace='root',
+                        repository='repo',
+                        alone=True,
+                        name='test0r',
+                        tracking='gitbucket')
+
+    def test_13_gist_list(self):
+        with pytest.raises(NotImplementedError):
+            g_list = []
+            self.action_gist_list(gist_list_data=g_list)
+
+    def test_14_gist_list_with_gist(self):
+        with pytest.raises(NotImplementedError):
+            g_list = [
+                "C                 2542  i2c_scanner.c"
+            ]
+            self.action_gist_list(gist='10118958')
+
+    def test_15_gist_list_with_bad_gist(self):
+        with pytest.raises(NotImplementedError):
+            self.action_gist_list(gist='42')
+
+    def test_16_gist_clone_with_gist(self):
+        with pytest.raises(NotImplementedError):
+            self.action_gist_clone(gist='https://gist.github.com/10118958')
+
+    def test_17_gist_fetch_with_gist(self):
+        with pytest.raises(NotImplementedError):
+            content = self.action_gist_fetch(gist='4170462', gist_file=None)
+            assert content == '\n'.join([
+                'diff --git a/platform/io.c b/platform/io.c',
+                'index 209666a..0a6c2cf 100644',
+                '--- a/platform/io.c',
+                '+++ b/platform/io.c',
+                '@@ -24,6 +24,16 @@',
+                ' #if defined(__FreeBSD__)',
+                ' #define IO_BSD',
+                ' #elif defined(__APPLE__)',
+                '+size_t strnlen(const char *s, size_t maxlen) ',
+                '+{ ',
+                '+        size_t len; ',
+                '+ ',
+                '+        for (len = 0; len < maxlen; len++, s++) { ',
+                '+                if (!*s) ',
+                '+                        break; ',
+                '+        } ',
+                '+        return (len); ',
+                '+} ',
+                ' #define IO_BSD',
+                ' #define IO_USE_SELECT',
+                ' #elif defined(WIN32)',
+            ])
+
+    def test_18_gist_fetch_with_bad_gist(self):
+        with pytest.raises(NotImplementedError):
+            self.action_gist_fetch(gist='69', gist_file=None)
+
+    def test_19_gist_fetch_with_gist_file(self):
+        with pytest.raises(NotImplementedError):
+            content = self.action_gist_fetch(gist='4170462', gist_file='freevpn0.029__platform__io.patch')
+            assert content == '\n'.join([
+                'diff --git a/platform/io.c b/platform/io.c',
+                'index 209666a..0a6c2cf 100644',
+                '--- a/platform/io.c',
+                '+++ b/platform/io.c',
+                '@@ -24,6 +24,16 @@',
+                ' #if defined(__FreeBSD__)',
+                ' #define IO_BSD',
+                ' #elif defined(__APPLE__)',
+                '+size_t strnlen(const char *s, size_t maxlen) ',
+                '+{ ',
+                '+        size_t len; ',
+                '+ ',
+                '+        for (len = 0; len < maxlen; len++, s++) { ',
+                '+                if (!*s) ',
+                '+                        break; ',
+                '+        } ',
+                '+        return (len); ',
+                '+} ',
+                ' #define IO_BSD',
+                ' #define IO_USE_SELECT',
+                ' #elif defined(WIN32)',
+            ])
+
+    def test_20_gist_fetch_with_bad_gist_file(self):
+        with pytest.raises(NotImplementedError):
+            self.action_gist_fetch(gist='4170462', gist_file='failed')
+
+    def test_21_gist_create_gist_file(self, datadir):
+        with pytest.raises(NotImplementedError):
+            test_file = str(datadir[ 'random-fortune-1.txt' ])
+            self.action_gist_create(description='this is a test.',
+                    gist_files=[ test_file ],
+                    secret=False)
+
+    def test_22_gist_create_gist_file_list(self, datadir):
+        with pytest.raises(NotImplementedError):
+            test_files = [
+                    str(datadir[ 'random-fortune-1.txt' ]),
+                    str(datadir[ 'random-fortune-2.txt' ]),
+                    str(datadir[ 'random-fortune-3.txt' ]),
+                    str(datadir[ 'random-fortune-4.txt' ]),
+            ]
+            self.action_gist_create(description='this is a test.',
+                    gist_files=test_files,
+                    secret=False)
+
+    def test_23_gist_create_gist_dir(self, datadir):
+        with pytest.raises(NotImplementedError):
+            test_dir = [
+                    str(datadir[ 'a_directory' ]),
+            ]
+            self.action_gist_create(description='this is a test.',
+                    gist_files=test_dir,
+                    secret=False)
+
+    def test_24_gist_create_gist_file(self, datadir):
+        with pytest.raises(NotImplementedError):
+            test_file = str(datadir[ 'random-fortune-1.txt' ])
+            self.action_gist_create(description='this is a secret test.',
+                    gist_files=[ test_file ],
+                    secret=True)
+
+    def test_25_gist_create_gist_file_list(self, datadir):
+        with pytest.raises(NotImplementedError):
+            test_files = [
+                    str(datadir[ 'random-fortune-1.txt' ]),
+                    str(datadir[ 'random-fortune-2.txt' ]),
+                    str(datadir[ 'random-fortune-3.txt' ]),
+                    str(datadir[ 'random-fortune-4.txt' ]),
+            ]
+            self.action_gist_create(description='this is a secret test.',
+                    gist_files=test_files,
+                    secret=True)
+
+    def test_26_gist_create_gist_dir(self, datadir):
+        with pytest.raises(NotImplementedError):
+            test_dir = [
+                    str(datadir[ 'a_directory' ]),
+            ]
+            self.action_gist_create(description='this is a secret test.',
+                    gist_files=test_dir,
+                    secret=True)
+
+    def test_27_gist_delete(self):
+        with pytest.raises(NotImplementedError):
+            self.action_gist_delete(gist='7dcc495dda5e684cba94940a01f60e95')
+
+    def test_28_gist_delete__not_exist(self):
+        with pytest.raises(NotImplementedError):
+            self.action_gist_delete(gist='7dcc495dda5e684cba94940a01f60e95')
+
+    def test_29_gist_create_gist__file_not_exist(self, datadir):
+        with pytest.raises(NotImplementedError):
+            test_dir = [
+                    'does_not_exists'
+            ]
+            self.action_gist_create(description='this is a secret test.',
+                    gist_files=test_dir,
+                    secret=False)
+
+    @pytest.mark.skip
+    def test_30_request_list(self):
+        self.action_request_list(
+                namespace='root',
+                repository='repo',
+                rq_list_data=[
+            '{}\t{:<60}\t{}',
+            ('id', 'title', 'URL'),
+            ('3', 'docs for fqdn > url', 'https://github.com/guyzmo/git-repo/pull/3'),
+            ('2', 'prefer gitrepo.<target>.token > privatekey, docs', 'https://github.com/guyzmo/git-repo/pull/2'),
+        ])
+
+    @pytest.mark.skip
+    def test_31_request_fetch(self):
+        self.action_request_fetch(namespace='root',
+                repository='repo',
+                request='1',
+                remote_branch='pull',
+                local_branch='requests/gitbucket')
+
+    @pytest.mark.skip
+    def test_31_request_fetch__bad_request(self):
+        with pytest.raises(ResourceNotFoundError):
+            self.action_request_fetch(namespace='guyzmo',
+                repository='git-repo',
+                request='1',
+                remote_branch='pull',
+                local_branch='requests/github',
+                fail=True)
+
+    @pytest.mark.skip
+    def test_32_request_create(self):
+        r = self.action_request_create(namespace=self.namespace,
+                repository='test_create_requests',
+                source_branch='pr-test',
+                target_branch='master',
+                title='PR test',
+                description='PR description')
+        assert r == {
+                'local': 'pr-test',
+                'ref': 1,
+                'remote': 'master',
+                'url': 'https://github.com/{}/test_create_requests/pull/1'.format(self.namespace),
+                }
+
+    @pytest.mark.skip
+    def test_32_request_create__bad_branch(self):
+        with pytest.raises(ResourceError):
+            self.action_request_create(namespace=self.namespace,
+                    repository='test_create_requests',
+                    source_branch='does_not_exists',
+                    target_branch='master',
+                    title='PR test',
+                    description='PR description')
+
+    @pytest.mark.skip
+    def test_32_request_create__bad_repo(self):
+        with pytest.raises(ResourceNotFoundError):
+            r = self.action_request_create(namespace=self.namespace,
+                    repository='does_not_exists',
+                    source_branch='pr-test',
+                    target_branch='master',
+                    title='PR test',
+                    description='PR description')
+
+    @pytest.mark.skip
+    def test_32_request_create__guess_branch(self):
+        r = self.action_request_create(namespace=self.namespace,
+                repository='test_create_requests',
+                source_branch=None,
+                target_branch=None,
+                title='PR test',
+                description='PR description')
+
+    def test_33_open(self):
+        self.action_open(namespace='root',
+                         repository='repo')
+
+    @pytest.mark.skip
+    def test_34_list__short(self, caplog):
+        projects = self.action_list(namespace='group')
+        assert projects == ['{}', ('Total repositories: 1',), ['git-repo-test/git-repo']]
+        assert 'GET https://api.github.com/users/git-repo-test/repos' in caplog.text
+
+    @pytest.mark.skip
+    def test_34_list__long(self, caplog):
+        projects = self.action_list(namespace='git-repo-test', _long=True)
+        assert projects == ['{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:12}\t{}',
+                ['Status', 'Commits', 'Reqs', 'Issues', 'Forks', 'Coders', 'Watch', 'Likes', 'Lang', 'Modif', 'Name'],
+                ['F ', '92', '0', '0', '0', '1', '0', '0', 'Python', 'Mar 30 2016', 'git-repo-test/git-repo']]
+        assert 'GET https://api.github.com/users/git-repo-test/repos' in caplog.text
+
+

--- a/tests/integration/test_gitbucket.py
+++ b/tests/integration/test_gitbucket.py
@@ -29,12 +29,11 @@ class Test_Gitbucket(GitRepoTestCase):
 
     def get_service(self):
         return gitbucket.GitbucketService(c={
-            '__name__': 'gitrepo "gitbucket-test"',
+            '__name__': 'gitrepo "gitbucket"',
             'fqdn': "localhost",
             'port': "8080",
             'scheme': "http",
             'insecure': 'yes',
-            'token': os.environ['GITBUCKET_TOKEN']
             })
 
     def get_requests_session(self):
@@ -65,8 +64,9 @@ class Test_Gitbucket(GitRepoTestCase):
 
 
     def test_02_delete(self):
-        self.action_delete(namespace=self.local_namespace,
-                           repository='foobar')
+        with pytest.raises(NotImplementedError):
+            self.action_delete(namespace=self.local_namespace,
+                               repository='foobar')
 
     def test_03_delete_nouser(self):
         with pytest.raises(NotImplementedError):

--- a/tests/integration/test_gitbucket.py
+++ b/tests/integration/test_gitbucket.py
@@ -21,10 +21,13 @@ from git_repo.exceptions import ResourceExistsError, ResourceNotFoundError, Reso
 
 class Test_Gitbucket(GitRepoTestCase):
     log = log
-    namespace = "user"
+    namespace = os.environ['GITBUCKET_NAMESPACE']
+
 
     @property
     def local_namespace(self):
+        if 'GITBUCKET_NAMESPACE' in os.environ:
+            return os.environ['GITBUCKET_NAMESPACE']
         return 'user'
 
     def get_service(self):
@@ -34,6 +37,7 @@ class Test_Gitbucket(GitRepoTestCase):
             'port': "8080",
             'scheme': "http",
             'insecure': 'yes',
+            'ssh-url': 'ssh://git@localhost:29418'
             })
 
     def get_requests_session(self):


### PR DESCRIPTION
[GitBucket](https://github.com/gitbucket/gitbucket) is Git platform with high-API compatibility to GitHub (for client, GitBucket looks like as GitHub Enterprise).
This PR add GitBucket support with some actions.

There are few changes to git-repo side.

- add support to ssh:// style remote.
- also support http, not only https.
- Change refspec in github.py:request_fetch

gitbucket.py now supports

- login with user created access token.
- list repositories
- clone repository
- fetch PR

these action doesn't supported now.

- automatic get access token by `git repo config`
- delete repository
- create PR
- list PR