### PR TITLE
Add support ssh:// URL and github local branch name fix.

### DIFF
--- a/git_repo/repo.py
+++ b/git_repo/repo.py
@@ -163,15 +163,15 @@ class GitRepoRunner(KeywordArgumentParser):
         for remote in repository.remotes:
             if remote.name in targets:
                 for url in remote.urls:
-                    if url.startswith('https'):
-                        if url.endswith('.git'):
-                            url = url[:-4]
+                    if url.endswith('.git'):
+                        url = url[:-4]
+                    if url.find('://') > -1:
+                        # http://, https:// and ssh://
                         *_, user, name = url.split('/')
                         self.set_repo_slug('/'.join([user, name]))
                         return
-                    elif url.startswith('git@'):
-                        if url.endswith('.git'):
-                            url = url[:-4]
+                    elif url.find('@') > -1 and url.find(':') > -1:
+                        # scp-style URL
                         _, repo_slug = url.split(':')
                         self.set_repo_slug(repo_slug)
                         return

--- a/git_repo/services/service.py
+++ b/git_repo/services/service.py
@@ -246,7 +246,10 @@ class RepositoryService:
         if not rw and '/' in repo:
             return '{}/{}'.format(self.url_ro, repo)
         elif rw and '/' in repo:
-            return '{}:{}'.format(self.url_rw, repo)
+            if self.url_rw.startswith('ssh://'):
+                return '{}/{}'.format(self.url_rw, repo)
+            else:
+                return '{}:{}'.format(self.url_rw, repo)
         else:
             raise ArgumentError("Cannot tell how to handle this url: `{}/{}`!".format(namespace, repo))
 


### PR DESCRIPTION
by [Git manual](https://git-scm.com/docs/git-clone#_git_urls_a_id_urls_a) git command also supports ssh:// style URL.  It is useful for GitBucket supoprt(#144).

And Gogs/Gitea can use any user for ssh access. This change accepts any user on scp-style `user@server:pathto/repo.git`.