### PR TITLE
Update gitlab init to remove deprecation warnings

### DIFF
--- a/git_repo/services/ext/gitlab.py
+++ b/git_repo/services/ext/gitlab.py
@@ -22,7 +22,7 @@ class GitlabService(RepositoryService):
     fqdn = 'gitlab.com'
 
     def __init__(self, *args, **kwarg):
-        self.gl = gitlab.Gitlab(self.url_ro)
+        self.gl = gitlab.Gitlab(self.url_ro, private_token=self._privatekey)
         super().__init__(*args, **kwarg)
 
     def connect(self):
@@ -31,8 +31,7 @@ class GitlabService(RepositoryService):
             self.gl.session.proxies.update(self.session_proxy)
 
         self.gl.set_url(self.url_ro)
-        self.gl.set_token(self._privatekey)
-        self.gl.token_auth()
+        self.gl.auth()
         self.username = self.gl.user.username
 
     def create(self, user, repo, add=False):


### PR DESCRIPTION
The python-gitlab [docs](http://python-gitlab.readthedocs.io/en/stable/api-usage.html#gitlab-gitlab-class) indicate that:

* the private key should be specified in the gitlab.Gitlab constructor (`gitlab.Gitlab.set_token` is deprecated)
* `gitlab.Gitlab.token_auth` is deprecated, should now be `gitlab.Gitlab.auth`

This pull request deals with both of these issues.

(BTW, the `set_url` call on [line 33](https://github.com/guyzmo/git-repo/blob/devel/git_repo/services/ext/gitlab.py#L33) seems to be redundant since the URL is specified when creating the `gitlab.Gitlab` instance, but I didn't have the time to test.)