### PR TITLE
Allow running git repo commands from sub directories in the repository

### DIFF
--- a/git_repo/repo.py
+++ b/git_repo/repo.py
@@ -159,9 +159,9 @@ class GitRepoRunner(KeywordArgumentParser):
             # Try to resolve existing repository path
             try:
                 try:
-                    repository = Repo(os.path.join(self.path, self.repo_name or ''))
+                    repository = Repo(os.path.join(self.path, self.repo_name or ''), search_parent_directories=True)
                 except NoSuchPathError:
-                    repository = Repo(self.path)
+                    repository = Repo(self.path, search_parent_directories=True)
             except InvalidGitRepositoryError:
                 raise FileNotFoundError('Cannot find path to the repository.')
             service = RepositoryService.get_service(repository, self.target)

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -2,6 +2,7 @@
 
 import logging
 import pytest
+import os
 
 #################################################################################
 # Enable logging
@@ -520,6 +521,13 @@ class Test_Main(GitRepoMainTestCase):
 
     def test_open__no_repo_slug__https(self):
         self._create_repository(ro=True)
+        repo_slug, seen_args = self.main_open(rc=0)
+        assert ('guyzmo', 'git-repo') == repo_slug
+        assert {} == seen_args
+
+    def test_open__from_sub_dir(self):
+        self._create_repository(ro=True)
+        os.chdir('git_repo')
         repo_slug, seen_args = self.main_open(rc=0)
         assert ('guyzmo', 'git-repo') == repo_slug
         assert {} == seen_args


### PR DESCRIPTION
This pull request allows you to use git-repo from any sub directory just like you can with the vanilla git client.

Before
```
❯ git hub request fetch 187
Successfully fetched request id `187` of `guyzmo/git-repo` into `requests/github/187`!
❯ cd git_repo/services
❯ git hub request fetch 187
Fatal error: Cannot find path to the repository.
```

After
```
❯ git hub request fetch 187
Successfully fetched request id `187` of `guyzmo/git-repo` into `requests/github/187`!
❯ cd git_repo/services
❯ git hub request fetch 187 
Successfully fetched request id `187` of `guyzmo/git-repo` into `requests/github/187`!
```

Git client behavior
```
❯ git status
On branch yellow_submarine
nothing to commit, working tree clean
❯ cd git_repo/services
❯ git status
On branch yellow_submarine
nothing to commit, working tree clean
```